### PR TITLE
Add load_file/1 and load_file!/1

### DIFF
--- a/lib/celixir.ex
+++ b/lib/celixir.ex
@@ -198,6 +198,33 @@ defmodule Celixir do
   end
 
   @doc """
+  Loads a CEL expression from a file and compiles it into a `Celixir.Program`.
+
+  ## Examples
+
+      {:ok, program} = Celixir.load_file("path/to/rule.cel")
+      Celixir.Program.eval(program, %{x: 42})
+  """
+  @spec load_file(String.t()) :: {:ok, Celixir.Program.t()} | {:error, String.t()}
+  def load_file(path) do
+    case File.read(path) do
+      {:ok, contents} -> compile(String.trim(contents))
+      {:error, reason} -> {:error, "failed to read #{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  @doc """
+  Like `load_file/1` but raises on error.
+  """
+  @spec load_file!(String.t()) :: Celixir.Program.t()
+  def load_file!(path) do
+    case load_file(path) do
+      {:ok, program} -> program
+      {:error, msg} -> raise Celixir.Error, message: msg
+    end
+  end
+
+  @doc """
   Compiles a CEL expression and returns a callable function.
 
   The returned function takes a bindings map (or `Celixir.Environment`) and

--- a/test/load_file_test.exs
+++ b/test/load_file_test.exs
@@ -1,0 +1,56 @@
+defmodule Celixir.LoadFileTest do
+  use ExUnit.Case
+
+  @tmp_dir System.tmp_dir!()
+
+  setup do
+    path = Path.join(@tmp_dir, "test_#{:erlang.unique_integer([:positive])}.cel")
+    on_exit(fn -> File.rm(path) end)
+    {:ok, path: path}
+  end
+
+  describe "load_file/1" do
+    test "loads and compiles a CEL expression from file", %{path: path} do
+      File.write!(path, "x * 2 + y")
+      {:ok, program} = Celixir.load_file(path)
+      assert {:ok, 11} = Celixir.Program.eval(program, %{x: 5, y: 1})
+    end
+
+    test "handles trailing whitespace/newlines", %{path: path} do
+      File.write!(path, "x + 1\n\n")
+      {:ok, program} = Celixir.load_file(path)
+      assert {:ok, 6} = Celixir.Program.eval(program, %{x: 5})
+    end
+
+    test "returns error for non-existent file" do
+      assert {:error, msg} = Celixir.load_file("/tmp/nonexistent_cel_file.cel")
+      assert msg =~ "failed to read"
+    end
+
+    test "returns error for invalid CEL expression", %{path: path} do
+      File.write!(path, "+++invalid")
+      assert {:error, _msg} = Celixir.load_file(path)
+    end
+  end
+
+  describe "load_file!/1" do
+    test "returns program on success", %{path: path} do
+      File.write!(path, "1 + 2")
+      program = Celixir.load_file!(path)
+      assert {:ok, 3} = Celixir.Program.eval(program)
+    end
+
+    test "raises on file not found" do
+      assert_raise Celixir.Error, fn ->
+        Celixir.load_file!("/tmp/nonexistent_cel_file.cel")
+      end
+    end
+
+    test "raises on invalid expression", %{path: path} do
+      File.write!(path, "+++invalid")
+      assert_raise Celixir.Error, fn ->
+        Celixir.load_file!(path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Celixir.load_file/1` that reads a CEL expression from a file and compiles it into a `Program`
- Add `Celixir.load_file!/1` bang variant that raises on error
- Trims whitespace/newlines from file contents before compilation
- Returns clear error messages for missing files and invalid expressions

## Test plan
- [x] Loads and compiles valid CEL from file
- [x] Handles trailing whitespace/newlines
- [x] Returns error tuple for missing files
- [x] Returns error tuple for invalid CEL syntax
- [x] Bang variant raises on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)