### PR TITLE
Add Celixir.API module with defcel macro

### DIFF
--- a/lib/celixir/api.ex
+++ b/lib/celixir/api.ex
@@ -1,0 +1,108 @@
+defmodule Celixir.API do
+  @moduledoc """
+  A macro-based way to define CEL function libraries.
+
+  ## Usage
+
+      defmodule MyApp.CelMath do
+        use Celixir.API, scope: "mymath"
+
+        defcel abs(x) do
+          Kernel.abs(x)
+        end
+
+        defcel clamp(val, lo, hi) do
+          val |> max(lo) |> min(hi)
+        end
+      end
+
+      env = Celixir.Environment.new() |> MyApp.CelMath.register()
+      Celixir.eval!("mymath.clamp(150, 0, 100)", env)
+      # => 100
+
+  Functions defined with `defcel` receive plain Elixir values (already
+  unwrapped from CEL internal types) and should return plain Elixir values.
+
+  ## Without a scope
+
+      defmodule MyApp.CelHelpers do
+        use Celixir.API
+
+        defcel greet(name) do
+          "Hello, \#{name}!"
+        end
+      end
+
+      env = Celixir.Environment.new() |> MyApp.CelHelpers.register()
+      Celixir.eval!("greet('world')", env)
+      # => "Hello, world!"
+  """
+
+  defmacro __using__(opts) do
+    scope = Keyword.get(opts, :scope)
+
+    quote do
+      import Celixir.API, only: [defcel: 2]
+      Module.register_attribute(__MODULE__, :cel_functions, accumulate: true)
+      @before_compile Celixir.API
+      @cel_scope unquote(scope)
+    end
+  end
+
+  @doc """
+  Defines a CEL-callable function.
+
+  The function receives plain Elixir values and should return a plain Elixir value.
+  """
+  defmacro defcel(call, do: body) do
+    {name, _meta, args} = call
+    args = args || []
+
+    quote do
+      @cel_functions {unquote(to_string(name)), unquote(length(args))}
+      def unquote(name)(unquote_splicing(args)) do
+        unquote(body)
+      end
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    functions = Module.get_attribute(env.module, :cel_functions)
+    scope = Module.get_attribute(env.module, :cel_scope)
+    mod = env.module
+
+    register_body =
+      for {name, arity} <- functions do
+        cel_name = if scope, do: "#{scope}.#{name}", else: name
+        func_atom = String.to_atom(name)
+        args = Macro.generate_arguments(arity, __MODULE__)
+
+        quote do
+          env =
+            Celixir.Environment.put_function(
+              env,
+              unquote(cel_name),
+              fn unquote_splicing(args) ->
+                unquote(mod).unquote(func_atom)(unquote_splicing(args))
+              end
+            )
+        end
+      end
+
+    quote do
+      @doc """
+      Registers all `defcel` functions into the given environment.
+      """
+      def register(env \\ Celixir.Environment.new()) do
+        unquote_splicing(register_body)
+        env
+      end
+
+      @doc false
+      def __cel_functions__, do: unquote(Macro.escape(functions))
+
+      @doc false
+      def __cel_scope__, do: unquote(scope)
+    end
+  end
+end

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -1,0 +1,94 @@
+defmodule Celixir.APITest do
+  use ExUnit.Case
+
+  defmodule MathAPI do
+    use Celixir.API, scope: "mymath"
+
+    defcel abs(x) do
+      Kernel.abs(x)
+    end
+
+    defcel clamp(val, lo, hi) do
+      val |> max(lo) |> min(hi)
+    end
+
+    defcel double(x) do
+      x * 2
+    end
+  end
+
+  defmodule UnscopedAPI do
+    use Celixir.API
+
+    defcel greet(name) do
+      "Hello, #{name}!"
+    end
+
+    defcel add(a, b) do
+      a + b
+    end
+  end
+
+  describe "scoped API" do
+    test "registers functions with scope prefix" do
+      env = MathAPI.register()
+      assert {:ok, 5} = Celixir.eval("mymath.abs(-5)", env)
+    end
+
+    test "clamp function works" do
+      env = MathAPI.register()
+      assert {:ok, 100} = Celixir.eval("mymath.clamp(150, 0, 100)", env)
+      assert {:ok, 0} = Celixir.eval("mymath.clamp(-10, 0, 100)", env)
+      assert {:ok, 50} = Celixir.eval("mymath.clamp(50, 0, 100)", env)
+    end
+
+    test "double function works" do
+      env = MathAPI.register()
+      assert {:ok, 10} = Celixir.eval("mymath.double(5)", env)
+    end
+
+    test "can combine with variables" do
+      env = MathAPI.register(Celixir.Environment.new(%{x: -42}))
+      assert {:ok, 42} = Celixir.eval("mymath.abs(x)", env)
+    end
+
+    test "__cel_functions__ returns function list" do
+      funcs = MathAPI.__cel_functions__()
+      assert {"abs", 1} in funcs
+      assert {"clamp", 3} in funcs
+      assert {"double", 1} in funcs
+    end
+
+    test "__cel_scope__ returns scope" do
+      assert MathAPI.__cel_scope__() == "mymath"
+    end
+  end
+
+  describe "unscoped API" do
+    test "registers functions without prefix" do
+      env = UnscopedAPI.register()
+      assert {:ok, "Hello, world!"} = Celixir.eval("greet('world')", env)
+    end
+
+    test "add function" do
+      env = UnscopedAPI.register()
+      assert {:ok, 7} = Celixir.eval("add(3, 4)", env)
+    end
+
+    test "__cel_scope__ returns nil" do
+      assert UnscopedAPI.__cel_scope__() == nil
+    end
+  end
+
+  describe "composing APIs" do
+    test "can register multiple APIs on same environment" do
+      env =
+        Celixir.Environment.new(%{val: -7})
+        |> MathAPI.register()
+        |> UnscopedAPI.register()
+
+      assert {:ok, 7} = Celixir.eval("mymath.abs(val)", env)
+      assert {:ok, "Hello, world!"} = Celixir.eval("greet('world')", env)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Celixir.API` module with `defcel` macro for defining CEL function libraries
- Support scoped (`use Celixir.API, scope: "math"`) and unscoped function registration
- Auto-generates `register/1` to inject all functions into an Environment
- Multiple API modules can be composed on the same environment

## Test plan
- [x] Scoped functions registered with correct prefix
- [x] Unscoped functions registered without prefix
- [x] Multiple API modules composable on same environment
- [x] Functions work with CEL variables
- [x] Introspection via `__cel_functions__/0` and `__cel_scope__/0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)