### PR TITLE
Add private storage to Environment

### DIFF
--- a/lib/celixir/environment.ex
+++ b/lib/celixir/environment.ex
@@ -47,7 +47,7 @@ defmodule Celixir.Environment do
       Celixir.eval!("format.currency(price, 'USD')", env)
   """
 
-  defstruct variables: %{}, functions: %{}, type_adapter: nil, container: nil, container_prefixes: [], locals: %{}
+  defstruct variables: %{}, functions: %{}, type_adapter: nil, container: nil, container_prefixes: [], locals: %{}, private: %{}
 
   @type t :: %__MODULE__{
           variables: %{String.t() => any()},
@@ -55,7 +55,8 @@ defmodule Celixir.Environment do
           type_adapter: module() | nil,
           container: String.t() | nil,
           container_prefixes: [String.t()],
-          locals: %{String.t() => any()}
+          locals: %{String.t() => any()},
+          private: %{any() => any()}
         }
 
   @doc "Creates a new empty environment."
@@ -137,6 +138,47 @@ defmodule Celixir.Environment do
   @doc "Looks up a function."
   def get_function(%__MODULE__{} = env, name) do
     Map.fetch(env.functions, name)
+  end
+
+  @doc """
+  Stores a private value in the environment.
+
+  Private values are not visible to CEL expressions — they are only
+  accessible from custom Elixir functions that receive the environment.
+
+  ## Examples
+
+      env = Celixir.Environment.new()
+            |> Celixir.Environment.put_private(:repo, MyApp.Repo)
+  """
+  def put_private(%__MODULE__{} = env, key, value) do
+    %{env | private: Map.put(env.private, key, value)}
+  end
+
+  @doc """
+  Retrieves a private value from the environment.
+
+  Returns `{:ok, value}` or `:error`.
+  """
+  def get_private(%__MODULE__{} = env, key) do
+    Map.fetch(env.private, key)
+  end
+
+  @doc """
+  Retrieves a private value, raising if the key doesn't exist.
+  """
+  def get_private!(%__MODULE__{} = env, key) do
+    case get_private(env, key) do
+      {:ok, value} -> value
+      :error -> raise KeyError, key: key, term: :private
+    end
+  end
+
+  @doc """
+  Deletes a private value from the environment.
+  """
+  def delete_private(%__MODULE__{} = env, key) do
+    %{env | private: Map.delete(env.private, key)}
   end
 
   @doc "Sets a custom type adapter module."

--- a/test/environment_private_test.exs
+++ b/test/environment_private_test.exs
@@ -1,0 +1,94 @@
+defmodule Celixir.EnvironmentPrivateTest do
+  use ExUnit.Case
+
+  alias Celixir.Environment
+
+  describe "put_private/3 and get_private/2" do
+    test "stores and retrieves a value" do
+      env = Environment.new() |> Environment.put_private(:key, "value")
+      assert {:ok, "value"} = Environment.get_private(env, :key)
+    end
+
+    test "returns :error for missing key" do
+      env = Environment.new()
+      assert :error = Environment.get_private(env, :missing)
+    end
+
+    test "supports string keys" do
+      env = Environment.new() |> Environment.put_private("api_key", "secret")
+      assert {:ok, "secret"} = Environment.get_private(env, "api_key")
+    end
+
+    test "overwrites existing value" do
+      env =
+        Environment.new()
+        |> Environment.put_private(:key, "old")
+        |> Environment.put_private(:key, "new")
+
+      assert {:ok, "new"} = Environment.get_private(env, :key)
+    end
+
+    test "multiple private keys" do
+      env =
+        Environment.new()
+        |> Environment.put_private(:a, 1)
+        |> Environment.put_private(:b, 2)
+
+      assert {:ok, 1} = Environment.get_private(env, :a)
+      assert {:ok, 2} = Environment.get_private(env, :b)
+    end
+  end
+
+  describe "get_private!/2" do
+    test "returns value when key exists" do
+      env = Environment.new() |> Environment.put_private(:key, 42)
+      assert 42 = Environment.get_private!(env, :key)
+    end
+
+    test "raises KeyError when key missing" do
+      env = Environment.new()
+      assert_raise KeyError, fn -> Environment.get_private!(env, :missing) end
+    end
+  end
+
+  describe "delete_private/2" do
+    test "removes a private key" do
+      env =
+        Environment.new()
+        |> Environment.put_private(:key, "value")
+        |> Environment.delete_private(:key)
+
+      assert :error = Environment.get_private(env, :key)
+    end
+
+    test "no-op for missing key" do
+      env = Environment.new() |> Environment.delete_private(:nope)
+      assert :error = Environment.get_private(env, :nope)
+    end
+  end
+
+  describe "private data is not visible to CEL" do
+    test "private keys are not accessible as variables" do
+      env =
+        Environment.new(%{x: 10})
+        |> Environment.put_private(:secret, "hidden")
+
+      assert {:ok, 10} = Celixir.eval("x", env)
+      assert {:error, _} = Celixir.eval("secret", env)
+    end
+  end
+
+  describe "private data in custom functions" do
+    test "custom function can close over env with private data" do
+      env =
+        Environment.new()
+        |> Environment.put_private(:multiplier, 3)
+
+      multiplier = Environment.get_private!(env, :multiplier)
+
+      env = Environment.put_function(env, "scale", fn x -> x * multiplier end)
+
+      assert {:ok, 15} = Celixir.eval("scale(5)", env)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `private` field to `Celixir.Environment` struct
- Add `put_private/3`, `get_private/2`, `get_private!/2`, `delete_private/2`
- Private data is invisible to CEL expressions, only accessible from Elixir custom functions
- Useful for carrying context like DB connections, API keys, or config

## Test plan
- [x] Store and retrieve private values (atom and string keys)
- [x] Overwrite and delete private values
- [x] `get_private!/2` raises on missing keys
- [x] Private keys not accessible as CEL variables
- [x] Custom functions can use private data via closures
- [x] Full test suite passes (2831 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)