### PR TITLE
Add encode/1 as inverse of unwrap

### DIFF
--- a/lib/celixir.ex
+++ b/lib/celixir.ex
@@ -277,4 +277,52 @@ defmodule Celixir do
   end
 
   def unwrap(v), do: v
+
+  @doc """
+  Encodes a plain Elixir value into CEL internal representation.
+
+  This is the inverse of `unwrap/1`. Since unwrapping loses some type
+  information (e.g., both `cel_int` and `cel_uint` unwrap to plain integers),
+  `encode` uses sensible defaults: integers become `{:cel_int, v}`.
+
+  ## Examples
+
+      iex> Celixir.encode(42)
+      {:cel_int, 42}
+
+      iex> Celixir.encode("hello")
+      "hello"
+
+      iex> Celixir.encode([1, 2, 3])
+      [{:cel_int, 1}, {:cel_int, 2}, {:cel_int, 3}]
+
+      iex> Celixir.encode(:optional_none)
+      %Celixir.Types.Optional{has_value: false}
+  """
+  def encode(v) when is_integer(v), do: {:cel_int, v}
+  def encode({:optional, v}), do: %Optional{has_value: true, value: encode(v)}
+  def encode(:optional_none), do: %Optional{has_value: false}
+  def encode(list) when is_list(list), do: Enum.map(list, &encode/1)
+
+  def encode(map) when is_map(map) and not is_struct(map) do
+    Map.new(map, fn {k, v} -> {encode(k), encode(v)} end)
+  end
+
+  def encode(v), do: v
+
+  @doc """
+  Encodes an integer as a CEL unsigned integer.
+
+      iex> Celixir.encode_uint(42)
+      {:cel_uint, 42}
+  """
+  def encode_uint(v) when is_integer(v) and v >= 0, do: {:cel_uint, v}
+
+  @doc """
+  Encodes a binary as CEL bytes.
+
+      iex> Celixir.encode_bytes(<<1, 2, 3>>)
+      {:cel_bytes, <<1, 2, 3>>}
+  """
+  def encode_bytes(v) when is_binary(v), do: {:cel_bytes, v}
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -1,0 +1,89 @@
+defmodule Celixir.EncodeTest do
+  use ExUnit.Case
+
+  alias Celixir.Types.Optional
+
+  describe "encode/1" do
+    test "integers become cel_int" do
+      assert Celixir.encode(42) == {:cel_int, 42}
+      assert Celixir.encode(0) == {:cel_int, 0}
+      assert Celixir.encode(-5) == {:cel_int, -5}
+    end
+
+    test "strings pass through" do
+      assert Celixir.encode("hello") == "hello"
+    end
+
+    test "floats pass through" do
+      assert Celixir.encode(3.14) == 3.14
+    end
+
+    test "booleans pass through" do
+      assert Celixir.encode(true) == true
+      assert Celixir.encode(false) == false
+    end
+
+    test "nil passes through" do
+      assert Celixir.encode(nil) == nil
+    end
+
+    test "lists are recursively encoded" do
+      assert Celixir.encode([1, 2, 3]) == [{:cel_int, 1}, {:cel_int, 2}, {:cel_int, 3}]
+      assert Celixir.encode(["a", 1]) == ["a", {:cel_int, 1}]
+    end
+
+    test "maps are recursively encoded" do
+      assert Celixir.encode(%{"a" => 1}) == %{"a" => {:cel_int, 1}}
+      assert Celixir.encode(%{1 => "x"}) == %{{:cel_int, 1} => "x"}
+    end
+
+    test "optional with value" do
+      assert Celixir.encode({:optional, 42}) == %Optional{has_value: true, value: {:cel_int, 42}}
+    end
+
+    test "optional none" do
+      assert Celixir.encode(:optional_none) == %Optional{has_value: false}
+    end
+
+    test "nested structures" do
+      input = %{"list" => [1, 2], "nested" => %{"x" => 3}}
+      expected = %{"list" => [{:cel_int, 1}, {:cel_int, 2}], "nested" => %{"x" => {:cel_int, 3}}}
+      assert Celixir.encode(input) == expected
+    end
+  end
+
+  describe "encode_uint/1" do
+    test "encodes as cel_uint" do
+      assert Celixir.encode_uint(42) == {:cel_uint, 42}
+      assert Celixir.encode_uint(0) == {:cel_uint, 0}
+    end
+  end
+
+  describe "encode_bytes/1" do
+    test "encodes as cel_bytes" do
+      assert Celixir.encode_bytes(<<1, 2, 3>>) == {:cel_bytes, <<1, 2, 3>>}
+      assert Celixir.encode_bytes("hello") == {:cel_bytes, "hello"}
+    end
+  end
+
+  describe "roundtrip encode/unwrap" do
+    test "unwrap(encode(v)) == v for simple values" do
+      for val <- [42, "hello", 3.14, true, false, nil] do
+        assert Celixir.unwrap(Celixir.encode(val)) == val
+      end
+    end
+
+    test "roundtrip for lists" do
+      assert Celixir.unwrap(Celixir.encode([1, 2, 3])) == [1, 2, 3]
+    end
+
+    test "roundtrip for maps" do
+      assert Celixir.unwrap(Celixir.encode(%{"a" => 1})) == %{"a" => 1}
+    end
+
+    test "roundtrip for optional" do
+      assert Celixir.unwrap(Celixir.encode({:optional, 5})) == {:optional, 5}
+      assert Celixir.unwrap(Celixir.encode(:optional_none)) == :optional_none
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Celixir.encode/1` to convert plain Elixir values to CEL internal types (inverse of `unwrap/1`)
- Add `Celixir.encode_uint/1` for explicit unsigned integer encoding
- Add `Celixir.encode_bytes/1` for explicit bytes encoding
- Recursively encodes lists and maps
- Handles optional values (`{:optional, v}` and `:optional_none`)

## Test plan
- [x] Integers encode to `{:cel_int, v}`
- [x] Strings, floats, booleans, nil pass through
- [x] Lists and maps recursively encoded
- [x] Optional values encoded correctly
- [x] `encode_uint/1` and `encode_bytes/1` work
- [x] Roundtrip: `unwrap(encode(v)) == v` for all types

🤖 Generated with [Claude Code](https://claude.com/claude-code)